### PR TITLE
Common use case implemented

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -86,8 +86,26 @@ class GraphAPI(object):
     get_user_from_cookie() method below to get the OAuth access token
     for the active user from the cookie saved by the SDK.
     """
-    def __init__(self, access_token=None):
+    def __init__(self, access_token=None, app_id=None, app_secret=None, allow_no_access_token=False):
+        self._app_id = app_id
+        self._app_secret = app_secret
+        if access_token is None and not allow_no_access_token:
+            access_token = self._get_token()
         self.access_token = access_token
+
+    def _get_token(self):
+        params = urllib.urlencode(dict(
+            client_id=self._app_id,
+            client_secret=self._app_secret,
+            type='client_cred'))
+        response = urllib.urlopen('https://graph.facebook.com/oauth/access_token?%s' % params).read()
+        if response:
+            print response
+            parsed = cgi.parse_qs(response)
+            if parsed and 'access_token' in parsed:
+                token = parsed['access_token'][0]
+                return token
+        return None
 
     def get_object(self, id, **args):
         """Fetchs the given object from the graph."""


### PR DESCRIPTION
This change makes it possible to grab some information about a user when you do not have their user access_token. There are 2 types of access_tokens, app and user. A user access_token will enable you to perform all operations for the user. Sometimes you just need to get their first name or their birthday, in which case you can use your app's access_token. All you need to do is ask for it from the FB oauth endpoint and pass it your secret key, (don't worry it's https :)
