### PR TITLE
Updated to work with OAuth 2.0

### DIFF
--- a/examples/appengine/example.html
+++ b/examples/appengine/example.html
@@ -5,7 +5,7 @@
     <title>Facebook Example</title>
   </head>
   <body>
-    <fb:login-button autologoutlink="true" perms="publish_stream"></fb:login-button>
+    <fb:login-button autologoutlink="true" scope="publish_stream"></fb:login-button>
 
     {% if current_user %}
       <p><a href="{{ current_user.profile_url }}"><img src="http://graph.facebook.com/{{ current_user.id }}/picture?type=square"/></a></p>


### PR DESCRIPTION
The currently commited version uses the keyword 'perms' instead of the currently accepted keyword 'scope'. Thus it does not work out of the box, this small change will allow it to work correctly.
