### PR TITLE
Post to a Facebook page with page_token param in attachment dict

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -250,8 +250,12 @@ class GraphAPI(object):
         args = args or {}
 
         if self.access_token:
-            if post_args is not None:
-                post_args["access_token"] = self.access_token
+            if post_args is not None:                
+                # if page_token arg is present in attachment dic it will post to a facebook page
+                if hasattr(post_args,'page_token'):
+                  post_args["access_token"] = post_args['page_token']
+                else:
+                  post_args["access_token"] = self.access_token
             else:
                 args["access_token"] = self.access_token
         post_data = None if post_args is None else urllib.urlencode(post_args)


### PR DESCRIPTION
This change makes it possible to post to a Facebook page by adding an optional parameter in the attachment dict called page_token.
Example:

access_token = "AAAEHrtUafwUBAM7As5UqEFxlTnnjw0Ge0A6vZC0m9Wx6y3BN5IeoTty2PucZCfpbLl9x"
page_id = "139738252786325"
msg = "Post test msg"
attachment = {
"name" : "Post test title",
"link" : "http://www.example.com",
"description" : "a description test",
"picture" : "http://www.example.com/logo.jpg",
"page_token" : "AAAEHrtUafwUBAImJvSbLeSmfiz3iR0i7JIT7UL2lTji9yiyfm8PmBO6aKK5ITCWAciseWZAtV"
}
graph = facebook.GraphAPI(access_token)
post = graph.put_wall_post(message=msg, attachment=attachment,profile_id=page_id)
