### PR TITLE
Convert strings to ascii before passing them to HMAC

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -469,6 +469,11 @@ def parse_signed_request(signed_request, app_secret):
     if data.get('algorithm', '').upper() != 'HMAC-SHA256':
         return False
 
+    # HMAC can only handle ascii (byte) strings
+    # http://bugs.python.org/issue5285
+    app_secret = app_secret.encode('ascii')
+    payload = payload.encode('ascii')
+
     expected_sig = hmac.new(app_secret,
                             msg=payload,
                             digestmod=hashlib.sha256).digest()


### PR DESCRIPTION
HMAC can only handle byte (i.e. ascii) strings as explained here: http://bugs.python.org/issue5285

This meant that when parse_signed_request was called with an Unicode app_secret an exception was raised.

I fixed the problem converting the two strings passed to HMAC to ascii inside parse_signed_request, so that the latter can now handle Unicode strings.
