### PR TITLE
Fixed error in readme.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ profile of the logged in user with:
 
     user = facebook.get_user_from_cookie(self.request.cookies, key, secret)
     if user:
-        graph = facebook.GraphAPI(user["oauth_access_token"])
+        graph = facebook.GraphAPI(user["access_token"])
         profile = graph.get_object("me")
         friends = graph.get_connections("me", "friends")
 


### PR DESCRIPTION
Readme was incorrectly accessing the dict returned from get_user_cookie.
It had the key as user['oauth_access_token'] instead of user['access_token'].
