### PR TITLE
Fixed two bugs of GraphAPIError

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -318,8 +318,7 @@ class GraphAPI(object):
         finally:
             file.close()
         if response and isinstance(response, dict) and response.get("error"):
-            raise GraphAPIError(response["error"]["type"],
-                                response["error"]["message"])
+            raise GraphAPIError(response)
         return response
 
     def fql(self, query, args=None, post_args=None):


### PR DESCRIPTION
Hi there,

I fixed two bugs of GraphAPIError.
### Wrongly paring of error response

with the commit 0f28100.

Test:

```
from facebook import GraphAPI, GraphAPIError
from pprint import pprint

graph = GraphAPI(access_token='123')

try:
    graph.get_object('me')
except GraphAPIError, e:
    print 'e.type: %r' % e.type
    print 'e.result:'
    pprint(e.result)
```

Result before fixed:

```
e.type: ''
e.result:
{'error': {'code': 190,
           'message': 'Invalid OAuth access token.',
           'type': 'OAuthException'}}
```

Result after fixed:

```
e.type: 190
e.result:
{'error': {'code': 190,
           'message': 'Invalid OAuth access token.',
           'type': 'OAuthException'}}
```
### Wrong parameters for GraphAPIError

Please see the commit fffe690.
