### PR TITLE
response_type and display added to auth_url

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -504,15 +504,18 @@ def parse_signed_request(signed_request, app_secret):
     return data
 
 
-def auth_url(app_id, canvas_url, perms=None, state=None):
+def auth_url(app_id, canvas_url, perms=None, state=None, response_type=None, display=None):
     url = "https://www.facebook.com/dialog/oauth?"
     kvps = {'client_id': app_id, 'redirect_uri': canvas_url}
     if perms:
         kvps['scope'] = ",".join(perms)
     if state:
         kvps['state'] = state
+    if response_type:
+        kvps['response_type'] = response_type
+    if display:
+        kvps['display'] = display
     return url + urllib.urlencode(kvps)
-
 
 def get_access_token_from_code(code, redirect_uri, app_id, app_secret):
     """Get an access token from the "code" returned from an OAuth dialog.


### PR DESCRIPTION
Added response_type so that an access token can be retrieved for client side authentication instead of the default code.
Added display in case the user the dialog is a popup or touch instead of default page.
http://developers.facebook.com/docs/reference/dialogs/oauth/
