### PR TITLE
Limit number of slices to two

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -472,7 +472,7 @@ def parse_signed_request(signed_request, app_secret):
 
     """
     try:
-        encoded_sig, payload = map(str, signed_request.split('.', 2))
+        encoded_sig, payload = map(str, signed_request.split('.', 1))
 
         sig = base64.urlsafe_b64decode(encoded_sig + "=" *
                                        ((4 - len(encoded_sig) % 4) % 4))


### PR DESCRIPTION
The second argument of str.split is maximum number of splits not slices.
