### PR TITLE
Fix syntax error in example code - add apostrophes to the put_photo json

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Photo uploads:
 ::
 
     graph = facebook.GraphAPI(oauth_access_token)
-    tags = json.dumps([{'x':50, 'y':50, tag_uid:12345}, {'x':10, 'y':60, tag_text:'a turtle'}])
+    tags = json.dumps([{'x':50, 'y':50, 'tag_uid':12345}, {'x':10, 'y':60, 'tag_text':'a turtle'}])
     graph.put_photo(open('img.jpg'), 'Look at this cool photo!', album_id_or_None, tags=tags)
 
 If you are using the module within a web application with the JavaScript SDK,


### PR DESCRIPTION
There is a syntax error in the example code, this is not really good for newcomers wanting to run example code....
