### PR TITLE
Added paginator support to connections

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -349,7 +349,9 @@ class GraphAPI(object):
                                 response["error"]["message"])
 
         next_url = response.get('paging', {}).get('next')
-        response = response.get('data')
+        data = response.get('data')
+        if data is not None:
+            response = data
         return response, next_url
 
     def fql(self, query, args=None, post_args=None):


### PR DESCRIPTION
Based on DRY principle, it is better to add paginator support in the module to avoid writing paginator codes everywhere.

Example:
```
generator = graph.get_connections(your_object_id, 'photos', as_generator=True)
for page, url in generator:
     do your stuff with the page
```

The default value of as_generator is False to maintain compatibility.

