### PR TITLE
BUGFIX: Missing 'Host' header when sending requests to TLS servers through proxies.

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -387,9 +387,9 @@ class GraphAPI(object):
             "grant_type": "fb_exchange_token",
             "fb_exchange_token": self.access_token,
         }
-        response = urllib.urlopen("https://graph.facebook.com/oauth/"
-                                  "access_token?" +
-                                  urllib.urlencode(args)).read()
+        response = urllib2.urlopen("https://graph.facebook.com/oauth/"
+                                   "access_token?" +
+                                   urllib.urlencode(args)).read()
         query_str = parse_qs(response)
         if "access_token" in query_str:
             result = {"access_token": query_str["access_token"][0]}
@@ -526,8 +526,8 @@ def get_access_token_from_code(code, redirect_uri, app_id, app_secret):
     }
     # We would use GraphAPI.request() here, except for that the fact
     # that the response is a key-value pair, and not JSON.
-    response = urllib.urlopen("https://graph.facebook.com/oauth/access_token" +
-                              "?" + urllib.urlencode(args)).read()
+    response = urllib2.urlopen("https://graph.facebook.com/oauth/access_token" +
+                               "?" + urllib.urlencode(args)).read()
     query_str = parse_qs(response)
     if "access_token" in query_str:
         result = {"access_token": query_str["access_token"][0]}


### PR DESCRIPTION
Missing 'Host' header when sending requests to TLS servers through proxies. Solved by using `urllib2.urlopen` everywhere instead of `urlli
