### PR TITLE
Error obtaining access token info when behind proxy (Tinyproxy/squid)

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -377,7 +377,7 @@ class GraphAPI(object):
             "grant_type": "fb_exchange_token",
             "fb_exchange_token": self.access_token,
         }
-        response = urllib.urlopen("https://graph.facebook.com/oauth/"
+        response = urllib2.urlopen("https://graph.facebook.com/oauth/"
                                   "access_token?" +
                                   urllib.urlencode(args)).read()
         query_str = parse_qs(response)
@@ -516,7 +516,7 @@ def get_access_token_from_code(code, redirect_uri, app_id, app_secret):
     }
     # We would use GraphAPI.request() here, except for that the fact
     # that the response is a key-value pair, and not JSON.
-    response = urllib.urlopen("https://graph.facebook.com/oauth/access_token" +
+    response = urllib2.urlopen("https://graph.facebook.com/oauth/access_token" +
                               "?" + urllib.urlencode(args)).read()
     query_str = parse_qs(response)
     if "access_token" in query_str:


### PR DESCRIPTION
Affected version: 0.4.0

I get the following error:
Message: [Errno socket error] [Errno -3] Temporary failure in name resolution
Method: facebook.get_user_from_cookie

The problem seems to be that urllib.urlopen is being used which does not support HTTP CONNECT requests to talk to https://graph.facebook.com/oauth/access_token from behind a proxy.

Using urllib2.urlopen fixes this issue.
