### PR TITLE
Changing the import and fallback order for json

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -46,12 +46,12 @@ import socket
 
 # Find a JSON parser
 try:
-    import simplejson as json
+    import json
 except ImportError:
     try:
-        from django.utils import simplejson as json
+        import simplejson as json
     except ImportError:
-        import json
+        from django.utils import simplejson as json
 _parse_json = json.loads
 
 # Find a query string parser


### PR DESCRIPTION
The json import order module imported the now obsolete django simplejson
parser before the parser bundled with the standard python library. The
new import schema is:
    1) json from the standard library
    2) simplejson
    3) simplejson from django, now osolete
