### PR TITLE
JSON updates

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -391,7 +391,7 @@ class GraphAPI(object):
                 result["expires"] = query_str["expires"][0]
             return result
         else:
-            response = json.loads(response)
+            response = _parse_json(response)
             raise GraphAPIError(response)
 
 
@@ -529,7 +529,7 @@ def get_access_token_from_code(code, redirect_uri, app_id, app_secret):
             result["expires"] = query_str["expires"][0]
         return result
     else:
-        response = json.loads(response)
+        response = _parse_json(response)
         raise GraphAPIError(response)
 
 


### PR DESCRIPTION
Using `simplejson` is an older convention. It should default to using the regular `json` library. There were also two places in the code that attempted to use json.loads() instead of the proxy method that is created. This pull request fixes both of those issues.
