### PR TITLE
using `json` as preferred parser, else fallback

### DIFF
--- a/facebook.py
+++ b/facebook.py
@@ -46,12 +46,13 @@ import socket
 
 # Find a JSON parser
 try:
-    import simplejson as json
+    import json
 except ImportError:
     try:
         from django.utils import simplejson as json
     except ImportError:
-        import json
+        import simplejson as json
+
 _parse_json = json.loads
 
 # Find a query string parser


### PR DESCRIPTION
Fallback on simplejson if required.
(since, DeprecationWarning: django.utils.simplejson is deprecated; use json instead)
