### PR TITLE
Added support for setting FB API version via api_version argument to GraphAPI.

### DIFF
--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -81,9 +81,22 @@ class GraphAPI(object):
     for the active user from the cookie saved by the SDK.
 
     """
-    def __init__(self, access_token=None, timeout=None):
+    def __init__(self, access_token=None, timeout=None, api_version=None):
         self.access_token = access_token
         self.timeout = timeout
+        if api_version is not None:
+            # 'api_version' can be string ("2", "2.0", "v2.0"), int (2), or float (2.0)
+            # and this will interpret it correctly.
+            if isinstance(api_version, basestring):
+                if api_version.startswith('v'):
+                    api_version = api_version[1:]
+
+                self.api_version = "v%.1f/" % (float(api_version))
+            else:
+                self.api_version = "v%.1f/" % (api_version)
+        else:
+            # If unset, it will use the default API version for this app.
+            self.api_version = ''
 
     def get_object(self, id, **args):
         """Fetchs the given object from the graph."""
@@ -201,7 +214,7 @@ class GraphAPI(object):
 
         try:
             response = requests.request(method or "GET",
-                                        "https://graph.facebook.com/" + path,
+                                        "https://graph.facebook.com/" + self.api_version + path,
                                         timeout=self.timeout,
                                         params=args,
                                         data=post_args,

--- a/test/test_facebook.py
+++ b/test/test_facebook.py
@@ -19,15 +19,7 @@ import unittest
 
 
 class FacebookTestCase(unittest.TestCase):
-    """Sets up application ID and secret from environment."""
-    def setUp(self):
-        try:
-            self.app_id = os.environ["FACEBOOK_APP_ID"]
-            self.secret = os.environ["FACEBOOK_SECRET"]
-        except KeyError:
-            raise Exception("FACEBOOK_APP_ID and FACEBOOK_SECRET "
-                            "must be set as environmental variables.")
-
+   pass
 
 class TestGetAppAccessToken(FacebookTestCase):
     """
@@ -37,10 +29,56 @@ class TestGetAppAccessToken(FacebookTestCase):
     whether it is valid.
 
     """
+    def setUp(self):
+        """Sets up application ID and secret from environment."""
+        try:
+            self.app_id = os.environ["FACEBOOK_APP_ID"]
+            self.secret = os.environ["FACEBOOK_SECRET"]
+        except KeyError:
+            raise Exception("FACEBOOK_APP_ID and FACEBOOK_SECRET "
+                            "must be set as environmental variables.")
     def test_get_app_access_token(self):
         token = facebook.get_app_access_token(self.app_id, self.secret)
-        assert(isinstance(token, str) or isinstance(token, unicode))
+        self.assertTrue(isinstance(token, str) or isinstance(token, unicode))
 
+
+class TestGetMe(FacebookTestCase):
+    def test_get_me(self):
+        access_token = os.environ["FACEBOOK_ACCESS_TOKEN"]
+        graph_api = facebook.GraphAPI(access_token)
+        me = graph_api.get_object("me")
+        self.assertTrue("name" in me)
+
+class TestVersioning(FacebookTestCase):
+    def test_version_as_number(self):
+        access_token = os.environ["FACEBOOK_ACCESS_TOKEN"]
+        graph_api = facebook.GraphAPI(access_token, api_version=1)
+        self.assertEqual("v1.0/", graph_api.api_version)
+        me = graph_api.get_object("me")
+        self.assertTrue("name" in me)
+
+        graph_api = facebook.GraphAPI(access_token, api_version=2.0)
+        self.assertEqual("v2.0/", graph_api.api_version)
+        me = graph_api.get_object("me")
+        self.assertTrue("name" in me)
+
+    def test_version_as_string(self):
+        access_token = os.environ["FACEBOOK_ACCESS_TOKEN"]
+
+        graph_api = facebook.GraphAPI(access_token, api_version="1")
+        self.assertEqual("v1.0/", graph_api.api_version)
+        me = graph_api.get_object("me")
+        self.assertTrue("name" in me)
+        
+        graph_api = facebook.GraphAPI(access_token, api_version="v1")
+        self.assertEqual("v1.0/", graph_api.api_version)
+        me = graph_api.get_object("me")
+        self.assertTrue("name" in me)
+
+        graph_api = facebook.GraphAPI(access_token, api_version="v2.0")
+        self.assertEqual("v2.0/", graph_api.api_version)
+        me = graph_api.get_object("me")
+        self.assertTrue("name" in me)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
'api_version' can be string ("2", "2.0", "v2.0"), int (2), or float (2.0).

Closes issue #154.
