### PR TITLE
return FQL data

### DIFF
--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -239,7 +239,7 @@ class GraphAPI(object):
         Example query: "SELECT affiliations FROM user WHERE uid = me()"
 
         """
-        self.request("fql", {"q": query})
+        return self.request("fql", {"q": query})
 
     def get_app_access_token(self, app_id, app_secret):
         """Get the application's access token as a string."""


### PR DESCRIPTION
After updating my facebook-sdk I noticed my FQL results were not returning anything.

Adding a return statement fixes the problem.
