### PR TITLE
Fix malformation of url if "version" is provided

### DIFF
--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -242,7 +242,6 @@ class GraphAPI(object):
                 url = GRAPH_URL + self.version + '/' + path
             else:
                 url = GRAPH_URL + path
-            print url
             response = requests.request(method or "GET",
                                         url,
                                         timeout=self.timeout,


### PR DESCRIPTION
When a version was specified to the GraphAPI constructor, the url in request() was malformed :

"https://graph.facebook.com/v2.1me" instead of "https://graph.facebook.com/v2.1/me".

It should be fixed by this commit.
