### PR TITLE
Add Graph API v2.2 as a valid version

### DIFF
--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -86,7 +86,7 @@ class GraphAPI(object):
     def __init__(self, access_token=None, timeout=None, version=None):
         # The default version is only used if the version kwarg does not exist.
         default_version = "1.0"
-        valid_API_versions = ["1.0", "2.0", "2.1"]
+        valid_API_versions = ["1.0", "2.0", "2.1", "2.2"]
 
         self.access_token = access_token
         self.timeout = timeout


### PR DESCRIPTION
2.1 is now outdated, Facebook announced 2.2 as its successor around Halloween.
https://developers.facebook.com/docs/graph-api/reference/v2.2
