### PR TITLE
Add `get_access_token` to the main example

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -41,7 +41,8 @@ You can read more about `Facebook's Graph API here`_.
 
     import facebook
 
-    graph = facebook.GraphAPI(access_token='your_token', version='2.2')
+    token = facebook.get_access_token('your_app_id', 'your_app_secret')  # consider caching this
+    graph = facebook.GraphAPI(access_token=token, version='2.2')
 
 Methods
 -------


### PR DESCRIPTION
I'm assuming that this is how most people are getting their token, so as a basic example, it would be helpful to include this.