### PR TITLE
Current docs don't show how to get an access token

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -41,7 +41,9 @@ You can read more about `Facebook's Graph API here`_.
 
     import facebook
 
-    graph = facebook.GraphAPI(access_token='your_token', version='2.2')
+    graph = facebook.GraphAPI(version=2.5)
+    graph.access_token = graph.get_app_access_token(
+        'your_app_id', 'your_app_secret')
 
 Methods
 -------


### PR DESCRIPTION
I had to pull this from the unit tests to figure out how to get and use access token cleanly. The current example is not enough, and fumbling through the docs/code first made me think that this was the only way to go about it, which is gross/wrong:

```
    graph = facebook.GraphAPI(
        facebook.GraphAPI().get_app_access_token(
            'your_app_id', 'your_app_secret'
        ),
        version='2.2'
    )
```

Please either merge this or update the docs so that someone can get a working example from just this first example.