### PR TITLE
Update Changelog Headers

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,13 +2,13 @@
 Changelog
 =========
 
-Version 2.0.0
-=============
+Version 2.0.0 (Future Release)
+==============================
  - Support Graph API version 2.6.
  - Allow offline generation of application access tokens.
 
-Version 1.0.0
-=============
+Version 1.0.0 (2016-04-01)
+==========================
 
  - Python 3 support.
  - More comprehensive test coverage.


### PR DESCRIPTION
1. The current Changelog Headers don't have the 1.0.0 release date
2. `2.0.0` isn't tagged/released, so it should either not be on here, or labeled as a future release
