### PR TITLE
Fix GraphAPIError An access token is required to request this resource.

### DIFF
--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -234,7 +234,7 @@ class GraphAPI(object):
             # or it does not need `access_token`.
             if post_args and "access_token" not in post_args:
                 post_args["access_token"] = self.access_token
-            elif args and "access_token" not in args:
+            elif "access_token" not in args:
                 args["access_token"] = self.access_token
 
         try:


### PR DESCRIPTION
When args is {}, usually occur during the instantiation of GraphAPI(). It does not enter the following line 237:
`args["access_token"] = self.access_token`

Thus, the `access_token` is missing when sending requests