### PR TITLE
Remove Graph API 2.0 support.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -25,8 +25,8 @@ You can read more about `Facebook's Graph API here`_.
 * ``timeout`` - A ``float`` describing (in seconds) how long the client will be
   waiting for a response from Facebook's servers. `See more here`_.
 * ``version`` - A ``string`` describing the `version of Facebook's Graph API to
-  use`_. Valid API versions are ``2.0``, ``2.1``, ``2.2``, ``2.3``, ``2.4``,
-  ``2.5``, ``2.6``, and ``2.7``. The default version is ``2.0`` and is used if
+  use`_. Valid API versions are ``2.1``, ``2.2``, ``2.3``, ``2.4``,
+  ``2.5``, ``2.6``, and ``2.7``. The default version is ``2.1`` and is used if
   the version keyword argument is not provided.
 * ``proxies`` - A ``dict`` with proxy-settings that Requests should use. `See Requests documentation`_.
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,7 +4,9 @@ Changelog
 
 Version 2.0.0 (Future Release)
 ==============================
- - Support Graph API version 2.6 and 2.7.
+ - Add support for Graph API versions 2.6 and 2.7.
+ - Remove support for Graph API version 2.0 and change default Graph API
+   version to 2.1.
  - Allow offline generation of application access tokens.
 
 Version 1.0.0 (2016-04-01)

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,8 +5,8 @@ Changelog
 Version 2.0.0 (Future Release)
 ==============================
  - Add support for Graph API versions 2.6 and 2.7.
- - Remove support for Graph API version 2.0 and change default Graph API
-   version to 2.1.
+ - Remove support for Graph API version 2.0 and FQL.
+ - Change default Graph API version to 2.1.
  - Allow offline generation of application access tokens.
 
 Version 1.0.0 (2016-04-01)

--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -79,7 +79,7 @@ class GraphAPI(object):
     def __init__(self, access_token=None, timeout=None, version=None,
                  proxies=None):
         # The default version is only used if the version kwarg does not exist.
-        default_version = "2.0"
+        default_version = VALID_API_VERSIONS[0]
 
         self.access_token = access_token
         self.timeout = timeout

--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -272,14 +272,6 @@ class GraphAPI(object):
             raise GraphAPIError(result)
         return result
 
-    def fql(self, query):
-        """FQL query.
-
-        Example query: "SELECT affiliations FROM user WHERE uid = me()"
-
-        """
-        return self.request(self.version + "/" + "fql", {"q": query})
-
     def get_app_access_token(self, app_id, app_secret, offline=False):
         """
         Get the application's access token as a string.

--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -44,7 +44,7 @@ __version__ = version.__version__
 
 FACEBOOK_GRAPH_URL = "https://graph.facebook.com/"
 FACEBOOK_OAUTH_DIALOG_URL = "https://www.facebook.com/dialog/oauth?"
-VALID_API_VERSIONS = ["2.0", "2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7"]
+VALID_API_VERSIONS = ["2.1", "2.2", "2.3", "2.4", "2.5", "2.6", "2.7"]
 
 
 class GraphAPI(object):

--- a/test/test_facebook.py
+++ b/test/test_facebook.py
@@ -112,23 +112,6 @@ class TestAPIVersion(FacebookTestCase):
                           facebook.GraphAPI, version="2.23")
 
 
-class TestFQL(FacebookTestCase):
-    def test_fql(self):
-        graph = facebook.GraphAPI(version=2.0)
-        graph.access_token = graph.get_app_access_token(
-            self.app_id, self.secret)
-
-        # Ensure that version is below 2.1. Facebook has stated that FQL is
-        # not present in this or future versions of the Graph API.
-        if graph.get_version() < 2.1:
-            # This is a tautology, but we are limited in what information
-            # we can retrieve with a proper OAuth access token.
-            fql_result = graph.fql(
-                "SELECT app_id from application where app_id = %s" %
-                self.app_id)
-            self.assertEqual(fql_result["data"][0]["app_id"], str(self.app_id))
-
-
 class TestAuthURL(FacebookTestCase):
     def test_auth_url(self):
         perms = ['email', 'birthday']


### PR DESCRIPTION
Remove support for Graph API 2.0 and FQL. Change default version to Graph API 2.1.