### PR TITLE
Add `access_token` to POST body for POST requests

### DIFF
--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -224,21 +224,28 @@ class GraphAPI(object):
         """
         args = args or {}
 
-        if post_args is not None:
-            method = "POST"
+        if method is None:
+            if post_args is not None or files is not None:
+                method = "POST"
+            else:
+                method = "GET"
 
         # Add `access_token` to post_args or args if it has not already been
         # included.
         if self.access_token:
-            # If post_args exists, we assume that args either does not exists
-            # or it does not need `access_token`.
-            if post_args and "access_token" not in post_args:
-                post_args["access_token"] = self.access_token
-            elif "access_token" not in args:
-                args["access_token"] = self.access_token
+            # `access_token` is passed in `post_args` for POST requests and it's
+            # passed in `args` (query string) if it's GET request.
+            if method == "POST":
+                if post_args is None:
+                    post_args = {}
+                if "access_token" not in post_args:
+                    post_args["access_token"] = self.access_token
+            else:
+                if "access_token" not in args:
+                    args["access_token"] = self.access_token
 
         try:
-            response = requests.request(method or "GET",
+            response = requests.request(method,
                                         FACEBOOK_GRAPH_URL + path,
                                         timeout=self.timeout,
                                         params=args,

--- a/test/test_facebook.py
+++ b/test/test_facebook.py
@@ -14,7 +14,9 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 import facebook
+import mock
 import os
+import requests
 import unittest
 
 try:
@@ -195,6 +197,62 @@ class TestParseSignedRequest(FacebookTestCase):
         self.assertTrue('code' in result)
         self.assertTrue('user_id' in result)
         self.assertTrue('algorithm' in result)
+
+
+@mock.patch('requests.request')
+class TestRequest(FacebookTestCase):
+    def test_get_object(self, request):
+        response = requests.Response()
+        response.headers['content-type'] = 'json'
+        response._content = '{}'
+        request.return_value = response
+
+        api = facebook.GraphAPI(access_token='my_token', version='2.7')
+        api.get_object('me')
+
+        self.assertEquals(request.call_args[0], ('GET', 'https://graph.facebook.com/v2.7/me'))
+        self.assertEquals(request.call_args[1]['params'], {'access_token': 'my_token'})
+
+    def test_put_comment(self, request):
+        response = requests.Response()
+        response.headers['content-type'] = 'json'
+        response._content = '{"success": true}'
+        request.return_value = response
+
+        api = facebook.GraphAPI(access_token='my_token', version='2.7')
+        api.put_comment('123456', 'Hello')
+
+        self.assertEquals(request.call_args[0], ('POST', 'https://graph.facebook.com/v2.7/123456/comments'))
+        self.assertEquals(request.call_args[1]['data'], {'access_token': 'my_token', 'message': 'Hello'})
+        self.assertEquals(request.call_args[1]['params'], {})
+
+
+    def test_put_like(self, request):
+        response = requests.Response()
+        response.headers['content-type'] = 'json'
+        response._content = '{"success": true}'
+        request.return_value = response
+
+        api = facebook.GraphAPI(access_token='my_token', version='2.7')
+        api.put_like('123456')
+
+        self.assertEquals(request.call_args[0], ('POST', 'https://graph.facebook.com/v2.7/123456/likes'))
+        self.assertEquals(request.call_args[1]['data'], {'access_token': 'my_token'})
+        self.assertEquals(request.call_args[1]['params'], {})
+
+    def test_put_photo(self, request):
+        response = requests.Response()
+        response.headers['content-type'] = 'json'
+        response._content = '{"success": true}'
+        request.return_value = response
+
+        api = facebook.GraphAPI(access_token='my_token', version='2.7')
+        api.put_photo('file-mock')
+
+        self.assertEquals(request.call_args[0], ('POST', 'https://graph.facebook.com/v2.7/me/photos'))
+        self.assertEquals(request.call_args[1]['data'], {'access_token': 'my_token'})
+        self.assertEquals(request.call_args[1]['files'], {'source': 'file-mock'})
+        self.assertEquals(request.call_args[1]['params'], {})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Some POST requests contain files with no additional data in `post_args`. In those cases, `access_token` was passed in query string. It would be better to always pass `access_token` in request body for all POST requests.
