### PR TITLE
Use consistent string formatting

### DIFF
--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -103,7 +103,7 @@ class GraphAPI(object):
 
     def get_object(self, id, **args):
         """Fetches the given object from the graph."""
-        return self.request(self.version + "/" + id, args)
+        return self.request("{0}/{1}".format(self.version, id), args)
 
     def get_objects(self, ids, **args):
         """Fetches all of the given object from the graph.
@@ -117,7 +117,7 @@ class GraphAPI(object):
     def get_connections(self, id, connection_name, **args):
         """Fetches the connections for given object."""
         return self.request(
-            "%s/%s/%s" % (self.version, id, connection_name), args)
+            "{0}/{1}/{2}".format(self.version, id, connection_name), args)
 
     def put_object(self, parent_object, connection_name, **data):
         """Writes the given object to the graph, connected to the given parent.
@@ -140,7 +140,7 @@ class GraphAPI(object):
         """
         assert self.access_token, "Write operations require an access token"
         return self.request(
-            self.version + "/" + parent_object + "/" + connection_name,
+            "{0}/{1}/{2}".format(self.version, parent_object, connection_name),
             post_args=data,
             method="POST")
 
@@ -173,11 +173,11 @@ class GraphAPI(object):
 
     def delete_object(self, id):
         """Deletes the object with the given ID from the graph."""
-        self.request(self.version + "/" + id, method="DELETE")
+        self.request("{0}/{1}".format(self.version, id), method="DELETE")
 
     def delete_request(self, user_id, request_id):
         """Deletes the Request with the given ID for the given user."""
-        self.request("%s_%s" % (request_id, user_id), method="DELETE")
+        self.request("{0}_{1}".format(request_id, user_id), method="DELETE")
 
     def put_photo(self, image, album_path="me/photos", **kwargs):
         """
@@ -188,7 +188,7 @@ class GraphAPI(object):
 
         """
         return self.request(
-            self.version + "/" + album_path,
+            "{0}/{1}".format(self.version, album_path),
             post_args=kwargs,
             files={"source": image},
             method="POST")
@@ -282,7 +282,7 @@ class GraphAPI(object):
         access-tokens#apptokens>
         """
         if offline:
-            return "%s|%s" % (app_id, app_secret)
+            return "{0}|{1}".format(app_id, app_secret)
         else:
             args = {'grant_type': 'client_credentials',
                     'client_id': app_id,
@@ -336,7 +336,7 @@ class GraphAPI(object):
         """
         args = {
             "input_token": token,
-            "access_token": "%s|%s" % (app_id, app_secret)
+            "access_token": "{0}|{1}".format(app_id, app_secret)
         }
         return self.request("/debug_token", args=args)
 

--- a/test/test_facebook.py
+++ b/test/test_facebook.py
@@ -68,7 +68,7 @@ class TestGetAppAccessToken(FacebookTestCase):
         """Verify that offline generation of app access tokens works."""
         token = facebook.GraphAPI().get_app_access_token(
             self.app_id, self.secret, offline=True)
-        self.assertEqual(token, "%s|%s" % (self.app_id, self.secret))
+        self.assertEqual(token, "{0}|{1}".format(self.app_id, self.secret))
 
     def test_get_deleted_app_access_token(self):
         deleted_app_id = '174236045938435'


### PR DESCRIPTION
Previously the code had a mix of string concatenation and old style formatting. Now all paths for `request` calls are consistently formatted (where it made sense).
