### PR TITLE
Detailed usage and example comment for auth_url method

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -271,3 +271,24 @@ Deletes the object with the given ID from the graph.
 .. code-block:: python
 
     graph.delete_object(id='post_id')
+
+auth_url
+^^^^^^^^^^^^^
+https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow
+
+Generates Facebook login URL to request access token and permissions.
+
+**Parameters**
+
+* ``app_id`` - ``integer`` Facebook application id that is requesting for authentication and authorisation.
+* ``canvas_url`` - ``string`` Return URL after successful authentication, usually parses returned Facebook response for authorisation request.
+* ``perms`` - ``list`` List of requested permissions.
+
+**Example**
+
+.. code-block:: python
+    app_id = 1231241241
+    canvas_url = 'https://domain.com/that-handles-auth-response/'
+    perms = ['manage_pages','publish_pages']
+    fb_login_url = graph.auth_url(app_id, canvas_url, perms)
+    print(fb_login_url)

--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -450,6 +450,14 @@ def parse_signed_request(signed_request, app_secret):
 
 
 def auth_url(app_id, canvas_url, perms=None, **kwargs):
+    """ Generates Facebook login URL to request access token and permissions
+    @app_id: integer
+    @canvas_url: string
+    @perms: list
+
+    Example:
+      fb_login_url = facebook.auth_url(1209312309123,'http://domain.com/handles/return',['manage_pages','publish_pages'])
+    """
     url = FACEBOOK_OAUTH_DIALOG_URL
     kvps = {'client_id': app_id, 'redirect_uri': canvas_url}
     if perms:

--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -450,13 +450,26 @@ def parse_signed_request(signed_request, app_secret):
 
 
 def auth_url(app_id, canvas_url, perms=None, **kwargs):
-    """ Generates Facebook login URL to request access token and permissions
-    @app_id: integer
-    @canvas_url: string
-    @perms: list
+    """ Generates Facebook login URL to request access token and permissions.
+    @app_id:
+        Type: integer
+        Description: Facebook application id that is requesting for authentication and authorisation.
+    @canvas_url:
+        Type: string
+        Description: Return URL after successful authentication, usually parses returned Facebook response for authorisation request.
+    @perms:
+        Type: list
+        Description: List of requested permissions.
 
     Example:
-      fb_login_url = facebook.auth_url(1209312309123,'http://domain.com/handles/return',['manage_pages','publish_pages'])
+       app_id = 1231241241
+       canvas_url = 'https://domain.com/that-handles-auth-response/'
+       perms = ['manage_pages','publish_pages']
+       fb_login_url = graph.auth_url(app_id, canvas_url, perms)
+       print(fb_login_url)
+
+    Refer to API Documentation:
+    https://facebook-sdk.readthedocs.io/en/latest/api.html
     """
     url = FACEBOOK_OAUTH_DIALOG_URL
     kvps = {'client_id': app_id, 'redirect_uri': canvas_url}


### PR DESCRIPTION
The changes will allow code editors to show usage and example code of the auth_url method to the SDK users without having to go to https://facebook-sdk.readthedocs.io/en/latest/api.html for reference.