### PR TITLE
Use json instead of data argument for requests.

### DIFF
--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -244,7 +244,7 @@ class GraphAPI(object):
                 FACEBOOK_GRAPH_URL + path,
                 timeout=self.timeout,
                 params=args,
-                data=post_args,
+                json=post_args,
                 proxies=self.proxies,
                 files=files)
         except requests.HTTPError as e:


### PR DESCRIPTION
`json` will behave the same as `data` except in the case of lists, which will now correctly JSON encode the post_args.


Note that since the post_args are created in this library, a consumer cannot simply encode the data as json to be passed to the graph.put_objects call, so this change is necessary to allow access to any facebook API that uses arrays, such as forms which require an array of question objects https://developers.facebook.com/docs/graph-api/reference/page/leadgen_forms/