### PR TITLE
fix(API): facebook.GraphAPI().request() "args" default to dict() instead of "None"

### DIFF
--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -216,7 +216,7 @@ class GraphAPI(object):
             raise GraphAPIError("API version number not available")
 
     def request(
-            self, path, args=None, post_args=None, files=None, method=None):
+            self, path, args=dict(), post_args=None, files=None, method=None):
         """Fetches the given path in the Graph API.
 
         We translate args to a valid query string. If post_args is

--- a/test/test_facebook.py
+++ b/test/test_facebook.py
@@ -197,5 +197,36 @@ class TestParseSignedRequest(FacebookTestCase):
         self.assertTrue('algorithm' in result)
 
 
+class TestAPIRequest(FacebookTestCase):
+    def test_request_args_by_none(self):
+        FB_VER = 2.7
+        FB_OBJECT_ID = "1846089248954071_1870020306560965"
+        token = facebook.GraphAPI().get_app_access_token(self.app_id, self.secret)
+        graph = facebook.GraphAPI(access_token=token, version=FB_VER)
+
+        # args=None
+        self.assertRaises(TypeError, graph.request, FB_OBJECT_ID, args=None, post_args=None)
+
+    def test_request_args_in_dict(self):
+        FB_VER = 2.7
+        FB_OBJECT_ID = "1846089248954071_1870020306560965"
+        token = facebook.GraphAPI().get_app_access_token(self.app_id, self.secret)
+        graph = facebook.GraphAPI(access_token=token, version=FB_VER)
+
+        # args=dict()
+        result = graph.request(FB_OBJECT_ID, args=dict(), post_args=None)
+        self.assertEqual(result["created_time"], "2016-12-24T05:20:55+0000")
+
+    def test_request_args_by_default(self):
+        FB_VER = 2.7
+        FB_OBJECT_ID = "1846089248954071_1870020306560965"
+        token = facebook.GraphAPI().get_app_access_token(self.app_id, self.secret)
+        graph = facebook.GraphAPI(access_token=token, version=FB_VER)
+
+        # default value set to: args=dict()
+        result = graph.request(FB_OBJECT_ID, post_args=None)
+        self.assertEqual(result["created_time"], "2016-12-24T05:20:55+0000")
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
args=None would cause TypeError: NoneType is not iterable
in case somebody call facebook.GraphAPI().request() directly