### PR TITLE
Change request method's args default again.

### DIFF
--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -232,7 +232,7 @@ class GraphAPI(object):
             raise GraphAPIError("API version number not available")
 
     def request(
-            self, path, args=dict(), post_args=None, files=None, method=None):
+            self, path, args=None, post_args=None, files=None, method=None):
         """Fetches the given path in the Graph API.
 
         We translate args to a valid query string. If post_args is
@@ -240,7 +240,8 @@ class GraphAPI(object):
         arguments.
 
         """
-
+        if args is None:
+            args = dict()
         if post_args is not None:
             method = "POST"
 

--- a/test/test_facebook.py
+++ b/test/test_facebook.py
@@ -281,6 +281,23 @@ class TestAPIRequest(FacebookTestCase):
         result = graph.request(FB_OBJECT_ID)
         self.assertEqual(result["created_time"], "2016-12-24T05:20:55+0000")
 
+    def test_request_access_tokens_are_unique_to_instances(self):
+        """Verify that access tokens are unique to each GraphAPI object."""
+        graph1 = facebook.GraphAPI(access_token="foo")
+        graph2 = facebook.GraphAPI(access_token="bar")
+        # We use `delete_object` so that the access_token will appear
+        # in request.__defaults__.
+        try:
+            graph1.delete_object("baz")
+        except facebook.GraphAPIError:
+            pass
+        try:
+            graph2.delete_object("baz")
+        except facebook.GraphAPIError:
+            pass
+        self.assertEqual(graph1.request.__defaults__[0], None)
+        self.assertEqual(graph2.request.__defaults__[0], None)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fix error caused by #340 which could cause args' default value to be a
dict containing arguments from past uses of the request method. Thanks
to @fractalis for reporting this.