### PR TITLE
Add function for retrieving user permissions

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -311,8 +311,28 @@ Generates Facebook login URL to request access token and permissions.
 **Example**
 
 .. code-block:: python
+
     app_id = 1231241241
     canvas_url = 'https://domain.com/that-handles-auth-response/'
     perms = ['manage_pages','publish_pages']
     fb_login_url = graph.auth_url(app_id, canvas_url, perms)
     print(fb_login_url)
+
+get_permissions
+^^^^^^^^^^^^^
+
+https://developers.facebook.com/docs/graph-api/reference/user/permissions/
+
+Returns the permissions granted to the app by the user with the given ID as a
+``set``.
+
+**Parameters**
+
+* ``user_id`` - A ``string`` containing a user's unique ID.
+
+**Example**
+
+.. code-block:: python
+
+    permissions = graph.get_permissions(user_id=12345)
+    print('public_profile' in permissions)

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,8 @@ Version 3.0.0 (unreleased)
  - Add support for requests' sessions (#201).
  - Add versioning to access token endpoints (#322).
  - Add new `get_all_connections` method to make pagination easier (#337).
+ - Add new `get_permissions` method to retrieve permissions that a user has
+   granted an application (#264, #342).
 
 Version 2.0.0 (2016-08-08)
 ==============================

--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -102,6 +102,13 @@ class GraphAPI(object):
         else:
             self.version = "v" + default_version
 
+    def get_permissions(self, user_id):
+        """Fetches the permissions object from the graph."""
+        response = self.request(
+            "{0}/{1}/permissions".format(self.version, user_id), {}
+            )["data"]
+        return {x["permission"] for x in response if x["status"] == "granted"}
+
     def get_object(self, id, **args):
         """Fetches the given object from the graph."""
         return self.request("{0}/{1}".format(self.version, id), args)

--- a/test/test_facebook.py
+++ b/test/test_facebook.py
@@ -299,5 +299,32 @@ class TestAPIRequest(FacebookTestCase):
         self.assertEqual(graph2.request.__defaults__[0], None)
 
 
+class TestGetUserPermissions(FacebookTestCase):
+    """
+    Test if user permissions are retrieved correctly.
+
+    Note that this only tests if the returned JSON object exists and is
+    structured as expected, not whether any specific scope is included
+    (other than the default `public_profile` scope).
+
+    """
+    def test_get_user_permissions_node(self):
+        token = facebook.GraphAPI().get_app_access_token(
+            self.app_id, self.secret)
+        graph = facebook.GraphAPI(access_token=token)
+        self.create_test_users(self.app_id, graph, 1)
+        permissions = graph.get_permissions(self.test_users[0]['id'])
+        self.assertIsNotNone(permissions)
+        self.assertTrue('public_profile' in permissions)
+        self.assertTrue('user_friends' in permissions)
+        self.assertFalse('email' in permissions)
+
+    def test_get_user_permissions_nonexistant_user(self):
+        token = facebook.GraphAPI().get_app_access_token(
+            self.app_id, self.secret)
+        with self.assertRaises(facebook.GraphAPIError):
+            facebook.GraphAPI(token).get_permissions(1)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This adds a function `get_permissions()` that returns the user permissions from the Graph API. To use this you must supply a user token.

This is the rebased and squashed code from [PR 264](https://github.com/mobolic/facebook-sdk/pull/264).