### PR TITLE
Drop API version 2.2 from VALID_API_VERSIONS

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -42,7 +42,7 @@ You can read more about `Facebook's Graph API here`_.
 
     import facebook
 
-    graph = facebook.GraphAPI(access_token='your_token', version='2.2')
+    graph = facebook.GraphAPI(access_token='your_token', version='2.8')
 
 Methods
 -------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,8 +6,8 @@ Version 3.0.0 (unreleased)
 ========================
  - Remove support for Python 2.6.
  - Add support for Graph API version 2.8.
- - Remove support for Graph API version 2.1.
- - Change default Graph API version to 2.2.
+ - Remove support for Graph API versions 2.1 and 2.2.
+ - Change default Graph API version to 2.3.
  - Add support for requests' sessions (#201).
  - Add versioning to access token endpoints (#322).
  - Add new `get_all_connections` method to make pagination easier (#337).

--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -45,7 +45,7 @@ __version__ = version.__version__
 
 FACEBOOK_GRAPH_URL = "https://graph.facebook.com/"
 FACEBOOK_OAUTH_DIALOG_URL = "https://www.facebook.com/dialog/oauth?"
-VALID_API_VERSIONS = ["2.2", "2.3", "2.4", "2.5", "2.6", "2.7", "2.8"]
+VALID_API_VERSIONS = ["2.3", "2.4", "2.5", "2.6", "2.7", "2.8"]
 
 
 class GraphAPI(object):


### PR DESCRIPTION
Facebook is terminating support for API version 2.2 on 25 March 2017 (see https://developers.facebook.com/docs/apps/changelog).