### PR TITLE
Fix typo in the docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -113,7 +113,7 @@ maps to an object.
 
     # Each given id maps to an object the contains the requested fields.
     for event_id in event_ids:
-        print(posts[event_id]['declined_count'])
+        print(events[event_id]['declined_count'])
 
 search
 ^^^^^^


### PR DESCRIPTION
Example contained posts instead of events, which was defined in the example. Mistake is probably from copy-pasting from the previous example.