### PR TITLE
Add URL string support when putting an image

### DIFF
--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -202,22 +202,22 @@ class GraphAPI(object):
         """
         Upload an image using image URL or multipart/form-data.
 
-        image - An image URL or a file object representing the image to be uploaded.
+        image - An URL or a file object representing the image to be uploaded.
         album_path - A path representing where the image should be uploaded.
         """
         payload = {
-            'path': self.version + "/" + album_path,
-            'post_args': kwargs,
-            'method': "POST"
+            "path": "{}/{}".format(self.version, album_path),
+            "post_args": kwargs,
+            "method": "POST"
         }
 
         if isinstance(image, str):
-            kwargs['url'] = image
+            kwargs["url"] = image
         else:
-            payload['files'] = {"source": image}
+            payload["files"] = {"source": image}
 
         return self.request(**payload)
-    
+
     def get_version(self):
         """Fetches the current version number of the Graph API being used."""
         args = {"access_token": self.access_token}

--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -200,18 +200,24 @@ class GraphAPI(object):
 
     def put_photo(self, image, album_path="me/photos", **kwargs):
         """
-        Upload an image using multipart/form-data.
+        Upload an image using image URL or multipart/form-data.
 
-        image - A file object representing the image to be uploaded.
+        image - An image URL or a file object representing the image to be uploaded.
         album_path - A path representing where the image should be uploaded.
-
         """
-        return self.request(
-            "{0}/{1}".format(self.version, album_path),
-            post_args=kwargs,
-            files={"source": image},
-            method="POST")
+        payload = {
+            'path': self.version + "/" + album_path,
+            'post_args': kwargs,
+            'method': "POST"
+        }
 
+        if isinstance(image, str):
+            kwargs['url'] = image
+        else:
+            payload['files'] = {"source": image}
+
+        return self.request(**payload)
+    
     def get_version(self):
         """Fetches the current version number of the Graph API being used."""
         args = {"access_token": self.access_token}


### PR DESCRIPTION
Facebook supports 2 modes when posting an image:
- By source
- By URL

I'd like to add the support for the 2nd mode which is missing at this moment.