### PR TITLE
GraphAPI - SSL Certificate Verification

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -30,12 +30,21 @@ You can read more about `Facebook's Graph API here`_.
 * ``proxies`` - A ``dict`` with proxy-settings that Requests should use.
   `See Requests documentation`_.
 * ``session`` - A `Requests Session object`_.
+* ``verify_ssl`` - Either a ``boolean``, in which case it controls whether we
+  verify the server's TLS certificate, or a ``string``, in which case it must
+  be a path to a CA bundle to use. Defaults to ``True``.
+  `See SSL Cert documentation`_.
+* ``cert_ssl`` - If ``string``, path to ssl client cert file (.pem). If
+  ``tuple``, ('cert', 'key') pair.
+  `See Client Side Certificates documentation`_.
 
 .. _Read more about access tokens here: https://developers.facebook.com/docs/facebook-login/access-tokens
 .. _See more here: http://docs.python-requests.org/en/latest/user/quickstart/#timeouts
 .. _version of Facebook's Graph API to use: https://developers.facebook.com/docs/apps/changelog#versions
 .. _See Requests documentation: http://www.python-requests.org/en/latest/user/advanced/#proxies
 .. _Requests Session object: http://docs.python-requests.org/en/master/user/advanced/#session-objects
+.. _See SSL Cert documentation: http://www.python-requests.org/en/latest/user/advanced/#ssl-cert-verification
+.. _See Client Side Certificates documentation: http://www.python-requests.org/en/latest/user/advanced/#client-side-certificates
 
 **Example**
 

--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -80,7 +80,7 @@ class GraphAPI(object):
     """
 
     def __init__(self, access_token=None, timeout=None, version=None,
-                 proxies=None, session=None):
+                 proxies=None, session=None, verify_ssl=None, cert_ssl=None):
         # The default version is only used if the version kwarg does not exist.
         default_version = VALID_API_VERSIONS[0]
 
@@ -88,6 +88,8 @@ class GraphAPI(object):
         self.timeout = timeout
         self.proxies = proxies
         self.session = session or requests.Session()
+        self.verify_ssl = verify_ssl
+        self.cert_ssl = cert_ssl
 
         if version:
             version_regex = re.compile("^\d\.\d{1,2}$")
@@ -222,7 +224,9 @@ class GraphAPI(object):
                 FACEBOOK_GRAPH_URL + self.version + "/me",
                 params=args,
                 timeout=self.timeout,
-                proxies=self.proxies)
+                proxies=self.proxies,
+                verify=self.verify_ssl,
+                cert=self.cert_ssl)
         except requests.HTTPError as e:
             response = json.loads(e.read())
             raise GraphAPIError(response)
@@ -266,6 +270,8 @@ class GraphAPI(object):
                 params=args,
                 data=post_args,
                 proxies=self.proxies,
+                verify=self.verify_ssl,
+                cert=self.cert_ssl,
                 files=files)
         except requests.HTTPError as e:
             response = json.loads(e.read())


### PR DESCRIPTION
At present, the GraphAPI does not contain verify and cert parameters which exist in requests.request. These parameters help in dealing with SSL certificate verification. In our project, we needed to bypass this verification but by default requests.request was verifying the SSL certificates and creating an issue for us. We simply included the said parameters in the GraphAPI as verify_ssl and verify_cert and used it subsequently in the call to requests.request

If some further changes are to be made, let us know - we could modify accordingly too