### PR TITLE
added header api call limits information to request result 

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -18,7 +18,8 @@ Version 3.0.0 (2018-08-08)
  - Add search method (#362).
  - Rename `auth_url` method to `get_auth_url` and move it into the Graph API
    object (#377, #378, #422).
- - Add `x-app-usage` `x-page-usage` Graph API response headers to result returned from GraphAPI's request method
+ - Add `x-app-usage` `x-page-usage` Graph API response headers to result
+   returned from GraphAPI's request method
 
 Version 2.0.0 (2016-08-08)
 ==========================

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -18,6 +18,7 @@ Version 3.0.0 (2018-08-08)
  - Add search method (#362).
  - Rename `auth_url` method to `get_auth_url` and move it into the Graph API
    object (#377, #378, #422).
+ - Add `x-app-usage` `x-page-usage` Graph API response headers to result returned from GraphAPI's request method
 
 Version 2.0.0 (2016-08-08)
 ==========================

--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -268,8 +268,11 @@ class GraphAPI(object):
             raise GraphAPIError(response)
 
         headers = response.headers
-        page_limits = json.loads(headers.get("x-page-usage"))
-        app_limits = json.loads(headers.get("x-app-usage"))
+        page_limits, app_limits = None, None
+        if "x-page-usage" in headers:
+            page_limits = json.loads(headers.get("x-page-usage"))
+        if "x-app-usage" in headers:
+            app_limits = json.loads(headers.get("x-app-usage"))
         if 'json' in headers['content-type']:
             result = response.json()
         elif 'image/' in headers['content-type']:

--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -268,11 +268,11 @@ class GraphAPI(object):
             raise GraphAPIError(response)
 
         headers = response.headers
-        page_limits, app_limits = None, None
+        x-page-usage, x-app-usage = None, None
         if "x-page-usage" in headers:
-            page_limits = json.loads(headers.get("x-page-usage"))
+            x-page-usage = json.loads(headers.get("x-page-usage"))
         if "x-app-usage" in headers:
-            app_limits = json.loads(headers.get("x-app-usage"))
+            x-app-usage = json.loads(headers.get("x-app-usage"))
         if 'json' in headers['content-type']:
             result = response.json()
         elif 'image/' in headers['content-type']:
@@ -293,8 +293,8 @@ class GraphAPI(object):
 
         if result and isinstance(result, dict) and result.get("error"):
             raise GraphAPIError(result)
-        result.update({'page_limits': page_limits,
-                       'app_limits': app_limits})
+        result.update({'x-page-usage': x-page-usage,
+                       'x-app-usage': x-app-usage})
         return result
 
     def get_app_access_token(self, app_id, app_secret, offline=False):

--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -268,6 +268,8 @@ class GraphAPI(object):
             raise GraphAPIError(response)
 
         headers = response.headers
+        page_limits = json.loads(headers.get("x-page-usage"))
+        app_limits = json.loads(headers.get("x-app-usage"))
         if 'json' in headers['content-type']:
             result = response.json()
         elif 'image/' in headers['content-type']:
@@ -288,6 +290,8 @@ class GraphAPI(object):
 
         if result and isinstance(result, dict) and result.get("error"):
             raise GraphAPIError(result)
+        result.update({'page_limits': page_limits,
+                       'app_limits': app_limits})
         return result
 
     def get_app_access_token(self, app_id, app_secret, offline=False):

--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -268,11 +268,11 @@ class GraphAPI(object):
             raise GraphAPIError(response)
 
         headers = response.headers
-        x-page-usage, x-app-usage = None, None
+        x_page_usage, x_app_usage = None, None
         if "x-page-usage" in headers:
-            x-page-usage = json.loads(headers.get("x-page-usage"))
+            x_page_usage = json.loads(headers.get("x-page-usage"))
         if "x-app-usage" in headers:
-            x-app-usage = json.loads(headers.get("x-app-usage"))
+            x_app_usage = json.loads(headers.get("x-app-usage"))
         if 'json' in headers['content-type']:
             result = response.json()
         elif 'image/' in headers['content-type']:
@@ -293,8 +293,8 @@ class GraphAPI(object):
 
         if result and isinstance(result, dict) and result.get("error"):
             raise GraphAPIError(result)
-        result.update({'x-page-usage': x-page-usage,
-                       'x-app-usage': x-app-usage})
+        result.update({'x-page-usage': x_page_usage,
+                       'x-app-usage': x_app_usage})
         return result
 
     def get_app_access_token(self, app_id, app_secret, offline=False):

--- a/test/test_facebook.py
+++ b/test/test_facebook.py
@@ -332,6 +332,30 @@ class TestAPIRequest(FacebookTestCase):
         self.assertEqual(graph1.request.__defaults__[0], None)
         self.assertEqual(graph2.request.__defaults__[0], None)
 
+    def test_request_result_has_x_app_usage_key(self):
+        """
+        Test if request() response has 'x-page-usage' key
+        """
+        FB_OBJECT_ID = "1846089248954071_1870020306560965"
+        token = facebook.GraphAPI().get_app_access_token(
+            self.app_id, self.secret, True)
+        graph = facebook.GraphAPI(access_token=token)
+
+        result = graph.request(FB_OBJECT_ID)
+        self.assertIn('x-app-usage', result.keys())
+
+    def test_request_result_has_x_page_usage_key(self):
+        """
+        Test if request() response has 'x-page-usage' key
+        """
+        FB_OBJECT_ID = "1846089248954071_1870020306560965"
+        token = facebook.GraphAPI().get_app_access_token(
+            self.app_id, self.secret, True)
+        graph = facebook.GraphAPI(access_token=token)
+
+        result = graph.request(FB_OBJECT_ID)
+        self.assertIn('x-page-usage', result.keys())
+
 
 class TestGetUserPermissions(FacebookTestCase):
     """


### PR DESCRIPTION
Facebook API has to call limits you can see documentation here:
[Facebook call limits](https://developers.facebook.com/docs/graph-api/advanced/rate-limiting)

So adding this information to the result you allow api user to control the amount of queries done in the last 60 minutes