### PR TITLE
Remove support for Graph API version 2.9.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -5,7 +5,8 @@ Changelog
 Version 3.2.0 (unreleased)
 ==========================
 - Add support for Graph API versions 3.2 and 3.3.
-- Change default Graph API version to 2.9.
+- Remove support for Graph API versions 2.8 and 2.9.
+- Change default Graph API version to 2.10.
 
 Version 3.1.0 (2018-11-06)
 ==========================

--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -46,16 +46,7 @@ __version__ = version.__version__
 FACEBOOK_GRAPH_URL = "https://graph.facebook.com/"
 FACEBOOK_WWW_URL = "https://www.facebook.com/"
 FACEBOOK_OAUTH_DIALOG_PATH = "dialog/oauth?"
-VALID_API_VERSIONS = [
-    "2.9",
-    "2.10",
-    "2.11",
-    "2.12",
-    "3.0",
-    "3.1",
-    "3.2",
-    "3.3",
-]
+VALID_API_VERSIONS = ["2.10", "2.11", "2.12", "3.0", "3.1", "3.2", "3.3"]
 VALID_SEARCH_TYPES = ["place", "placetopic"]
 
 


### PR DESCRIPTION
  - Remove support for Graph API version 2.9.
  - Change default Graph API version to 2.10.
  - Add missing changelog entry about removal of Graph API version 2.8.