### PR TITLE
Add subcodes to GraphAPIError.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -9,6 +9,7 @@ Version 3.2.0 (unreleased)
 - Change default Graph API version to 2.10.
 - Add support for securing Graph API Calls with a proof based on the
   application secret (#454).
+- Add subcodes to GraphAPIError objects.
 
 Version 3.1.0 (2018-11-06)
 ==========================

--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -429,6 +429,8 @@ class GraphAPIError(Exception):
     def __init__(self, result):
         self.result = result
         self.code = None
+        self.error_subcode = None
+
         try:
             self.type = result["error_code"]
         except (KeyError, TypeError):
@@ -442,6 +444,7 @@ class GraphAPIError(Exception):
             try:
                 self.message = result["error"]["message"]
                 self.code = result["error"].get("code")
+                self.error_subcode = result["error"].get("error_subcode")
                 if not self.type:
                     self.type = result["error"].get("type", "")
             except (KeyError, TypeError):

--- a/test/test_graphapierror.py
+++ b/test/test_graphapierror.py
@@ -1,0 +1,31 @@
+import random
+import string
+import unittest
+
+from facebook import GraphAPIError
+
+
+class FacebookTestCase(unittest.TestCase):
+    """Automated test cases specifically relating to GraphAPIError object."""
+
+    def test_default_error_subcode(self):
+        """Verify that default error subcode is None."""
+        error = GraphAPIError(None)
+        self.assertEqual(error.error_subcode, None)
+
+    def test_setting_error_subcode(self):
+        """Verify that error subcode is set properly."""
+        # Generate random string.
+        error_subcode = "".join(
+            random.choice(string.ascii_letters + string.digits)
+            for _ in range(10)
+        )
+        result = {
+            "error": {
+                "message": "",
+                "code": "",
+                "error_subcode": error_subcode,
+            }
+        }
+        error = GraphAPIError(result)
+        self.assertEqual(error.error_subcode, error_subcode)


### PR DESCRIPTION
Add `error_subcode` field to GraphAPIError objects if it exists.

Close #432. Close #453.