### PR TITLE
Update supported Graph API versions.

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -4,8 +4,8 @@ Changelog
 
 Version 3.2.0 (unreleased)
 ==========================
-- Add support for Graph API versions 3.2, 3.3, and 4.0.
-- Remove support for Graph API versions 2.8 and 2.9.
+- Add support for Graph API versions 3.2, 3.3, 4.0, and 5.0.
+- Remove support for Graph API versions 2.8, 2.9, and 2.10.
 - Change default Graph API version to 2.10.
 - Add support for securing Graph API Calls with a proof based on the
   application secret (#454).

--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -46,16 +46,7 @@ __version__ = version.__version__
 FACEBOOK_GRAPH_URL = "https://graph.facebook.com/"
 FACEBOOK_WWW_URL = "https://www.facebook.com/"
 FACEBOOK_OAUTH_DIALOG_PATH = "dialog/oauth?"
-VALID_API_VERSIONS = [
-    "2.10",
-    "2.11",
-    "2.12",
-    "3.0",
-    "3.1",
-    "3.2",
-    "3.3",
-    "4.0",
-]
+VALID_API_VERSIONS = ["2.11", "2.12", "3.0", "3.1", "3.2", "3.3", "4.0", "5.0"]
 VALID_SEARCH_TYPES = ["place", "placetopic"]
 
 


### PR DESCRIPTION
  - Remove deprecated version 2.10.
  - Add new version 5.0.