### PR TITLE
Update import SQLAlchemy

### DIFF
--- a/examples/flask/app/__init__.py
+++ b/examples/flask/app/__init__.py
@@ -1,5 +1,5 @@
 from flask import Flask
-from flask.ext.sqlalchemy import SQLAlchemy
+from flask_sqlalchemy import SQLAlchemy
 
 app = Flask(__name__)
 app.config.from_object("config")


### PR DESCRIPTION
The "flask.ext" style of naming/importing modules has been deprecated for a number of years now. You should use from flask_sqlalchemy import SQLAlchemy instead.