### PR TITLE
softened version check and set default version to 13.0

### DIFF
--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -41,7 +41,7 @@ __version__ = version.__version__
 FACEBOOK_GRAPH_URL = "https://graph.facebook.com/"
 FACEBOOK_WWW_URL = "https://www.facebook.com/"
 FACEBOOK_OAUTH_DIALOG_PATH = "dialog/oauth?"
-VALID_API_VERSIONS = ["3.1", "3.2", "3.3", "4.0", "5.0", "6.0", "7.0", "8.0"]
+DEFAULT_VERSION = "13.0"
 VALID_SEARCH_TYPES = ["place", "placetopic"]
 
 
@@ -83,9 +83,6 @@ class GraphAPI(object):
         session=None,
         app_secret=None,
     ):
-        # The default version is only used if the version kwarg does not exist.
-        default_version = VALID_API_VERSIONS[0]
-
         self.access_token = access_token
         self.timeout = timeout
         self.proxies = proxies
@@ -93,23 +90,18 @@ class GraphAPI(object):
         self.app_secret_hmac = None
 
         if version:
-            version_regex = re.compile(r"^\d\.\d{1,2}$")
+            version_regex = re.compile(r"^\d+\.\d{1,2}$")
             match = version_regex.search(str(version))
             if match is not None:
-                if str(version) not in VALID_API_VERSIONS:
-                    raise GraphAPIError(
-                        "Valid API versions are "
-                        + str(VALID_API_VERSIONS).strip("[]")
-                    )
-                else:
-                    self.version = "v" + str(version)
+                self.version = "v" + str(version)
             else:
                 raise GraphAPIError(
                     "Version number should be in the"
                     " following format: #.# (e.g. 2.0)."
                 )
         else:
-            self.version = "v" + default_version
+            # The default version is only used if the version kwarg does not exist.
+            self.version = "v" + DEFAULT_VERSION
 
         if app_secret and access_token:
             self.app_secret_hmac = hmac.new(

--- a/test/test_versions.py
+++ b/test/test_versions.py
@@ -13,9 +13,8 @@ class FacebookAPIVersionTestCase(FacebookTestCase):
         )
 
     def test_valid_versions(self):
-        for version in facebook.VALID_API_VERSIONS:
-            graph = facebook.GraphAPI(version=version)
-            self.assertEqual(str(graph.get_version()), version)
+        graph = facebook.GraphAPI(version=facebook.DEFAULT_VERSION)
+        self.assertEqual(str(graph.get_version()), facebook.DEFAULT_VERSION)
 
     def test_invalid_version(self):
         self.assertRaises(


### PR DESCRIPTION
This change removes the check against VALID_API_VERSIONS, which always required changes to the library (eg #496, #502), when a new Graph API version has been released. Instead only the pattern check is executed.

I've also changed the default API version to the latest Graph API version v13.0.