### PR TITLE
Add support for Graph API v12.0

### DIFF
--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -45,7 +45,7 @@ __version__ = version.__version__
 FACEBOOK_GRAPH_URL = "https://graph.facebook.com/"
 FACEBOOK_WWW_URL = "https://www.facebook.com/"
 FACEBOOK_OAUTH_DIALOG_PATH = "dialog/oauth?"
-VALID_API_VERSIONS = ["3.1", "3.2", "3.3", "4.0", "5.0", "6.0", "7.0", "8.0", "9.0", "10.0"]
+VALID_API_VERSIONS = ["3.1", "3.2", "3.3", "4.0", "5.0", "6.0", "7.0", "8.0", "9.0", "10.0", "11.0"]
 VALID_SEARCH_TYPES = ["place", "placetopic"]
 
 

--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -45,7 +45,7 @@ __version__ = version.__version__
 FACEBOOK_GRAPH_URL = "https://graph.facebook.com/"
 FACEBOOK_WWW_URL = "https://www.facebook.com/"
 FACEBOOK_OAUTH_DIALOG_PATH = "dialog/oauth?"
-VALID_API_VERSIONS = ["3.1", "3.2", "3.3", "4.0", "5.0", "6.0", "7.0", "8.0", "9.0", "10.0", "11.0"]
+VALID_API_VERSIONS = ["3.1", "3.2", "3.3", "4.0", "5.0", "6.0", "7.0", "8.0", "9.0", "10.0", "11.0", "12.0"]
 VALID_SEARCH_TYPES = ["place", "placetopic"]
 
 

--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -45,7 +45,7 @@ __version__ = version.__version__
 FACEBOOK_GRAPH_URL = "https://graph.facebook.com/"
 FACEBOOK_WWW_URL = "https://www.facebook.com/"
 FACEBOOK_OAUTH_DIALOG_PATH = "dialog/oauth?"
-VALID_API_VERSIONS = ["3.1", "3.2", "3.3", "4.0", "5.0", "6.0", "7.0", "8.0", "9.0"]
+VALID_API_VERSIONS = ["3.1", "3.2", "3.3", "4.0", "5.0", "6.0", "7.0", "8.0", "9.0", "10.0"]
 VALID_SEARCH_TYPES = ["place", "placetopic"]
 
 
@@ -97,7 +97,7 @@ class GraphAPI(object):
         self.app_secret_hmac = None
 
         if version:
-            version_regex = re.compile(r"^\d\.\d{1,2}$")
+            version_regex = re.compile(r"^\d{1,2}\.\d{1,2}$")
             match = version_regex.search(str(version))
             if match is not None:
                 if str(version) not in VALID_API_VERSIONS:

--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -31,7 +31,11 @@ import base64
 import requests
 import json
 import re
-from urllib.parse import parse_qs, urlencode, urlparse
+try:
+    from urllib.parse import parse_qs, urlencode, urlparse
+except ImportError:
+    from urlparse import parse_qs, urlparse
+    from urllib import urlencode
 
 from . import version
 

--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -45,7 +45,7 @@ __version__ = version.__version__
 FACEBOOK_GRAPH_URL = "https://graph.facebook.com/"
 FACEBOOK_WWW_URL = "https://www.facebook.com/"
 FACEBOOK_OAUTH_DIALOG_PATH = "dialog/oauth?"
-VALID_API_VERSIONS = ["3.1", "3.2", "3.3", "4.0", "5.0", "6.0", "7.0", "8.0"]
+VALID_API_VERSIONS = ["3.1", "3.2", "3.3", "4.0", "5.0", "6.0", "7.0", "8.0", "9.0"]
 VALID_SEARCH_TYPES = ["place", "placetopic"]
 
 


### PR DESCRIPTION
Adding support for Graph API v12.0 as v11.0 and below will be deprecated by 22 Feb 2022
