### PR TITLE
Removes support for deprecated Graph API Version 3.1

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -69,9 +69,3 @@ Version 0.3.2 (2012-07-28)
  - Fixes bug with Unicode app secrets.
  - Add optional timeout support for faster API requests.
  - Random PEP8 compliance fixes.
-
-Version 0.3.1 (2012-05-16)
-==========================
-
- - Minor documentation updates.
- - Removes the develop branch in favor of named feature branches.

--- a/examples/flask/requirements.txt
+++ b/examples/flask/requirements.txt
@@ -1,3 +1,3 @@
-facebook-sdk==3.1.0
+facebook-sdk==3.2.0
 flask>=0.12.3
 flask-sqlalchemy==2.1

--- a/facebook/__init__.py
+++ b/facebook/__init__.py
@@ -41,7 +41,7 @@ __version__ = version.__version__
 FACEBOOK_GRAPH_URL = "https://graph.facebook.com/"
 FACEBOOK_WWW_URL = "https://www.facebook.com/"
 FACEBOOK_OAUTH_DIALOG_PATH = "dialog/oauth?"
-VALID_API_VERSIONS = ["3.1", "3.2", "3.3", "4.0", "5.0", "6.0", "7.0", "8.0"]
+VALID_API_VERSIONS = ["3.2", "3.3", "4.0", "5.0", "6.0", "7.0", "8.0"]
 VALID_SEARCH_TYPES = ["place", "placetopic"]
 
 


### PR DESCRIPTION
This change resolves #490 by updating requirement variables to drop 3.1. I also updated the documentation.

Signed-off-by: Justin Dhillon <justin.singh.dhillon@gmail.com>